### PR TITLE
[TASK-07] Implement comprehensive API security with Supabase Auth and Storage

### DIFF
--- a/unet360-api/adapter/api/auth_routes.py
+++ b/unet360-api/adapter/api/auth_routes.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, HTTPException, status, Request
+from fastapi import APIRouter, HTTPException, status, Request, Depends
 import logging
 from gotrue.errors import AuthApiError
 import traceback
@@ -6,10 +6,11 @@ import traceback
 from core.dtos.responses_dto import GeneralResponse
 from core.dtos.auth_dto import UserSignUpDTO, UserLoginDTO, AuthResponseDTO
 from core.services.tenant_service import TenantService
-from core.dtos.tenant_dto import TenantCreateDTO
-
 from adapter.database.tenant_repository import TenantRepository
 
+from core.services.auth_service import AuthService
+
+from supabase import Client as SupabaseClient
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
@@ -18,56 +19,31 @@ tenant_service = TenantService(TenantRepository())
 
 router = APIRouter(prefix="/auth", tags=["Authentication"])
 
+def get_auth_service(request: Request) -> AuthService:
+    supabase_client_instance: SupabaseClient = request.app.state.supabase
+    return AuthService(supabase_client_instance, tenant_service)
+
+
 @router.post("/signup", response_model=GeneralResponse)
-async def signup_user(user_data: UserSignUpDTO, request: Request):
+async def signup_user(user_data: UserSignUpDTO, 
+                      auth_service: AuthService = Depends(get_auth_service)):
     try:
-        supabase_client = request.app.state.supabase
-
-        if not user_data.email.endswith('@unet.edu.ve'):
-            return GeneralResponse(
-                http_code=status.HTTP_400_BAD_REQUEST,
-                status=False,
-                response_obj={"message": "Registration allowed only for '@unet.edu.ve' email addresses."}
-            )
+        signup_result = await auth_service.signup_user(user_data)
         
-        response_supabase = supabase_client.auth.sign_up(
-            {
-                "email": user_data.email,
-                "password": user_data.password
-            }
-        )
-
-        if response_supabase.user is None:
-            return GeneralResponse(
-                http_code=status.HTTP_400_BAD_REQUEST,
-                status=False,
-                response_obj={"message": "Supabase signup failed: Could not create user."}
-            )
-        
-        supabase_user_id = response_supabase.user.id
-
-        tenant_create_dto_instance = TenantCreateDTO(
-            name=user_data.email.split('@')[0],
-            supabase_user_id=supabase_user_id,
-            role="viewer"
-        )
-        
-        await tenant_service.create_tenant(tenant_create_dto_instance)
-
         return GeneralResponse(
             http_code=status.HTTP_201_CREATED,
             status=True,
-            response_obj={"message": "User successfully registered. Please check your email to confirm your account."}
+            response_obj=signup_result
         )
 
-    except AuthApiError as e:
+    except HTTPException as e:
         return GeneralResponse(
-            http_code=status.HTTP_400_BAD_REQUEST,
+            http_code=e.status_code,
             status=False,
-            response_obj={"message": e.message}
+            response_obj={"message": e.detail}
         )
     except Exception as e:
-        logger.error(f"An unexpected error occurred during signup: {e}")
+        logger.error(f"An unexpected error occurred during signup in route: {e}")
         traceback.print_exc()
         return GeneralResponse(
             http_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
@@ -77,51 +53,25 @@ async def signup_user(user_data: UserSignUpDTO, request: Request):
 
 
 @router.post("/login", response_model=GeneralResponse)
-async def login_user(user_data: UserLoginDTO, request: Request):
+async def login_user(user_data: UserLoginDTO, 
+                     auth_service: AuthService = Depends(get_auth_service)):
     try:
-        supabase_client = request.app.state.supabase
-
-        response_supabase = supabase_client.auth.sign_in_with_password(
-            {
-                "email": user_data.email,
-                "password": user_data.password
-            }
-        )
-
-        supabase_user_id = response_supabase.user.id
-        access_token = response_supabase.session.access_token
-        expires_in = response_supabase.session.expires_in
-
-        tenant = await tenant_service.get_tenant_by_supabase_user_id(supabase_user_id)
+        auth_response_dto = await auth_service.login_user(user_data)
         
-        if not tenant:
-            return GeneralResponse(
-                http_code=status.HTTP_404_NOT_FOUND,
-                status=False,
-                response_obj={"message": "User authenticated, but tenant profile not found in MongoDB."}
-            )
-
-        auth_response = AuthResponseDTO(
-            access_token=access_token,
-            user_id=supabase_user_id,
-            user_role=tenant.role,
-            expires_in=expires_in
-        )
-
         return GeneralResponse(
             http_code=status.HTTP_200_OK,
             status=True,
-            response_obj=auth_response.model_dump()
+            response_obj=auth_response_dto.model_dump()
         )
 
-    except AuthApiError as e:
+    except HTTPException as e:
         return GeneralResponse(
-            http_code=status.HTTP_401_UNAUTHORIZED,
+            http_code=e.status_code,
             status=False,
-            response_obj={"message": e.message}
+            response_obj={"message": e.detail}
         )
     except Exception as e:
-        logger.error(f"An unexpected error occurred during login: {e}")
+        logger.error(f"An unexpected error occurred during login in route: {e}")
         traceback.print_exc()
         return GeneralResponse(
             http_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
@@ -131,62 +81,77 @@ async def login_user(user_data: UserLoginDTO, request: Request):
 
 @router.get("/status", response_model=GeneralResponse)
 async def get_auth_status(request: Request):
-    """
-    Endpoint para que el frontend verifique si el usuario está autenticado.
-    Esta ruta está excluida del AuthMiddleware.
-    """
-    user_id = getattr(request.state, "user_id", None)
-    user_role = getattr(request.state, "user_role", None)
+    try:
+        user_id = getattr(request.state, "user_id", None)
+        user_role = getattr(request.state, "user_role", None)
 
-    if user_id and user_role:
+        if user_id and user_role:
+            return GeneralResponse(
+                http_code=status.HTTP_200_OK,
+                status=True,
+                response_obj={
+                    "is_authenticated": True,
+                    "user_id": user_id,
+                    "user_role": user_role
+                }
+            )
+        else:
+            return GeneralResponse(
+                http_code=status.HTTP_200_OK,
+                status=False,
+                response_obj={
+                    "is_authenticated": False,
+                    "message": "User is not authenticated."
+                }
+            )
+    except HTTPException as e:
         return GeneralResponse(
-            http_code=status.HTTP_200_OK,
-            status=True,
-            response_obj={
-                "is_authenticated": True,
-                "user_id": user_id,
-                "user_role": user_role
-            }
-        )
-    else:
-        return GeneralResponse(
-            http_code=status.HTTP_200_OK, # Se devuelve 200 OK porque la petición fue exitosa, solo que el usuario no está autenticado
-            status=False, # Status False para indicar que la autenticación no está activa
+            http_code=e.status_code,
+            status=False,
             response_obj={
                 "is_authenticated": False,
-                "message": "User is not authenticated."
+                "message": e.detail
             }
         )
-    
+    except Exception as e:
+        logger.error(f"An unexpected error occurred in auth status: {e}")
+        traceback.print_exc()
+        return GeneralResponse(
+            http_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            status=False,
+            response_obj={
+                "is_authenticated": False,
+                "message": f"An unexpected error occurred: {str(e)}"
+            }
+        )
+
 @router.post("/logout", response_model=GeneralResponse)
-async def logout_user(request: Request):
+async def logout_user(request: Request,
+                      auth_service: AuthService = Depends(get_auth_service)):
     try:
-        supabase_client = request.app.state.supabase
-        
         user_id = getattr(request.state, "user_id", None)
         if not user_id:
             raise HTTPException(
                 status_code=status.HTTP_401_UNAUTHORIZED,
                 detail="Not authenticated. Cannot log out."
             )
-        response_supabase = supabase_client.auth.sign_out()
         
-        logger.info(f"User {user_id} successfully logged out from Supabase.")
+        logout_result = await auth_service.logout_user(user_id)
         
         return GeneralResponse(
             http_code=status.HTTP_200_OK,
             status=True,
-            response_obj={"message": "User successfully logged out."}
+            response_obj=logout_result
         )
 
-    except AuthApiError as e:
-        logger.error(f"AuthApiError during logout for user {user_id}: {e.message}")
+    except HTTPException as e:
         return GeneralResponse(
+            http_code=e.status_code,
             status=False,
-            response_obj={"message": f"Logout failed: {e.message}"}
+            response_obj={"message": e.detail}
         )
     except Exception as e:
-        logger.error(f"An unexpected error occurred during logout for user {user_id}: {e}")
+        logger.error(f"An unexpected error occurred during logout in route: {e}")
         traceback.print_exc()
         return GeneralResponse(
             http_code=status.HTTP_500_INTERNAL_SERVER_ERROR,

--- a/unet360-api/adapter/api/auth_routes.py
+++ b/unet360-api/adapter/api/auth_routes.py
@@ -1,0 +1,195 @@
+from fastapi import APIRouter, HTTPException, status, Request
+import logging
+from gotrue.errors import AuthApiError
+import traceback
+
+from core.dtos.responses_dto import GeneralResponse
+from core.dtos.auth_dto import UserSignUpDTO, UserLoginDTO, AuthResponseDTO
+from core.services.tenant_service import TenantService
+from core.dtos.tenant_dto import TenantCreateDTO
+
+from adapter.database.tenant_repository import TenantRepository
+
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.DEBUG)
+
+tenant_service = TenantService(TenantRepository())
+
+router = APIRouter(prefix="/auth", tags=["Authentication"])
+
+@router.post("/signup", response_model=GeneralResponse)
+async def signup_user(user_data: UserSignUpDTO, request: Request):
+    try:
+        supabase_client = request.app.state.supabase
+
+        if not user_data.email.endswith('@unet.edu.ve'):
+            return GeneralResponse(
+                http_code=status.HTTP_400_BAD_REQUEST,
+                status=False,
+                response_obj={"message": "Registration allowed only for '@unet.edu.ve' email addresses."}
+            )
+        
+        response_supabase = supabase_client.auth.sign_up(
+            {
+                "email": user_data.email,
+                "password": user_data.password
+            }
+        )
+
+        if response_supabase.user is None:
+            return GeneralResponse(
+                http_code=status.HTTP_400_BAD_REQUEST,
+                status=False,
+                response_obj={"message": "Supabase signup failed: Could not create user."}
+            )
+        
+        supabase_user_id = response_supabase.user.id
+
+        tenant_create_dto_instance = TenantCreateDTO(
+            name=user_data.email.split('@')[0],
+            supabase_user_id=supabase_user_id,
+            role="viewer"
+        )
+        
+        await tenant_service.create_tenant(tenant_create_dto_instance)
+
+        return GeneralResponse(
+            http_code=status.HTTP_201_CREATED,
+            status=True,
+            response_obj={"message": "User successfully registered. Please check your email to confirm your account."}
+        )
+
+    except AuthApiError as e:
+        return GeneralResponse(
+            http_code=status.HTTP_400_BAD_REQUEST,
+            status=False,
+            response_obj={"message": e.message}
+        )
+    except Exception as e:
+        logger.error(f"An unexpected error occurred during signup: {e}")
+        traceback.print_exc()
+        return GeneralResponse(
+            http_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            status=False,
+            response_obj={"message": f"An unexpected error occurred: {str(e)}"}
+        )
+
+
+@router.post("/login", response_model=GeneralResponse)
+async def login_user(user_data: UserLoginDTO, request: Request):
+    try:
+        supabase_client = request.app.state.supabase
+
+        response_supabase = supabase_client.auth.sign_in_with_password(
+            {
+                "email": user_data.email,
+                "password": user_data.password
+            }
+        )
+
+        supabase_user_id = response_supabase.user.id
+        access_token = response_supabase.session.access_token
+        expires_in = response_supabase.session.expires_in
+
+        tenant = await tenant_service.get_tenant_by_supabase_user_id(supabase_user_id)
+        
+        if not tenant:
+            return GeneralResponse(
+                http_code=status.HTTP_404_NOT_FOUND,
+                status=False,
+                response_obj={"message": "User authenticated, but tenant profile not found in MongoDB."}
+            )
+
+        auth_response = AuthResponseDTO(
+            access_token=access_token,
+            user_id=supabase_user_id,
+            user_role=tenant.role,
+            expires_in=expires_in
+        )
+
+        return GeneralResponse(
+            http_code=status.HTTP_200_OK,
+            status=True,
+            response_obj=auth_response.model_dump()
+        )
+
+    except AuthApiError as e:
+        return GeneralResponse(
+            http_code=status.HTTP_401_UNAUTHORIZED,
+            status=False,
+            response_obj={"message": e.message}
+        )
+    except Exception as e:
+        logger.error(f"An unexpected error occurred during login: {e}")
+        traceback.print_exc()
+        return GeneralResponse(
+            http_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            status=False,
+            response_obj={"message": f"An unexpected error occurred: {str(e)}"}
+        )
+
+@router.get("/status", response_model=GeneralResponse)
+async def get_auth_status(request: Request):
+    """
+    Endpoint para que el frontend verifique si el usuario está autenticado.
+    Esta ruta está excluida del AuthMiddleware.
+    """
+    user_id = getattr(request.state, "user_id", None)
+    user_role = getattr(request.state, "user_role", None)
+
+    if user_id and user_role:
+        return GeneralResponse(
+            http_code=status.HTTP_200_OK,
+            status=True,
+            response_obj={
+                "is_authenticated": True,
+                "user_id": user_id,
+                "user_role": user_role
+            }
+        )
+    else:
+        return GeneralResponse(
+            http_code=status.HTTP_200_OK, # Se devuelve 200 OK porque la petición fue exitosa, solo que el usuario no está autenticado
+            status=False, # Status False para indicar que la autenticación no está activa
+            response_obj={
+                "is_authenticated": False,
+                "message": "User is not authenticated."
+            }
+        )
+    
+@router.post("/logout", response_model=GeneralResponse)
+async def logout_user(request: Request):
+    try:
+        supabase_client = request.app.state.supabase
+        
+        user_id = getattr(request.state, "user_id", None)
+        if not user_id:
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="Not authenticated. Cannot log out."
+            )
+        response_supabase = supabase_client.auth.sign_out()
+        
+        logger.info(f"User {user_id} successfully logged out from Supabase.")
+        
+        return GeneralResponse(
+            http_code=status.HTTP_200_OK,
+            status=True,
+            response_obj={"message": "User successfully logged out."}
+        )
+
+    except AuthApiError as e:
+        logger.error(f"AuthApiError during logout for user {user_id}: {e.message}")
+        return GeneralResponse(
+            status=False,
+            response_obj={"message": f"Logout failed: {e.message}"}
+        )
+    except Exception as e:
+        logger.error(f"An unexpected error occurred during logout for user {user_id}: {e}")
+        traceback.print_exc()
+        return GeneralResponse(
+            http_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            status=False,
+            response_obj={"message": f"An unexpected error occurred: {str(e)}"}
+        )

--- a/unet360-api/adapter/api/location_routes.py
+++ b/unet360-api/adapter/api/location_routes.py
@@ -1,19 +1,19 @@
-from fastapi import APIRouter, HTTPException, status
+from fastapi import APIRouter, HTTPException, status, Depends
 from typing import List, Optional, Any
 
-from core.dtos.responses_dto import GeneralResponse 
-
-from core.services.location_service import LocationService
 from adapter.database.location_repository import LocationRepository
+from core.services.location_service import LocationService
 from core.dtos.location_dto import LocationCreateDTO, LocationOutDTO, LocationUpdateDTO
-
+from core.dtos.responses_dto import GeneralResponse 
+from core.dependencies.auth_dependencies import get_current_admin_user
 
 router = APIRouter(prefix="/locations", tags=["Locations"])
 
 service = LocationService(LocationRepository()) 
 
 @router.post("/", response_model=GeneralResponse)
-async def create_locations(dto: LocationCreateDTO):
+async def create_locations(dto: LocationCreateDTO, 
+                           current_user_id: str = Depends(get_current_admin_user)):
     try:
         created_location_dto = await service.create_location(dto) 
         
@@ -83,7 +83,8 @@ async def get_all_locations():
         )
 
 @router.patch("/{name}", response_model=GeneralResponse)
-async def update_location(name: str, dto: LocationUpdateDTO):
+async def update_location(name: str, dto: LocationUpdateDTO, 
+                          current_user_id: str = Depends(get_current_admin_user)):
     try:
         updated_location_dto = await service.update_location(name, dto)
         
@@ -106,7 +107,8 @@ async def update_location(name: str, dto: LocationUpdateDTO):
         )
 
 @router.delete("/{name}", response_model=GeneralResponse)
-async def delete_location(name: str):
+async def delete_location(name: str, 
+                           current_user_id: str = Depends(get_current_admin_user)):
     try:
         delete_result = await service.delete_location(name)
         

--- a/unet360-api/adapter/api/main.py
+++ b/unet360-api/adapter/api/main.py
@@ -21,7 +21,7 @@ from adapter.api.tag_routes import router as tag_router
 from adapter.api.node_routes import router as node_router    
 from adapter.api.tenant_routes import router as tenant_router              
 from adapter.api.auth_routes import router as auth_router
-
+from adapter.api.upload_routes import router as upload_router
 
 load_dotenv()
 logger = logging.getLogger('uvicorn.error')
@@ -61,7 +61,8 @@ routers = [
     tag_router,
     node_router,
     tenant_router,
-    auth_router
+    auth_router,
+    upload_router
 ]
 
 app = FastAPI(title="UNET360 API", lifespan=lifespan)

--- a/unet360-api/adapter/api/tag_routes.py
+++ b/unet360-api/adapter/api/tag_routes.py
@@ -1,19 +1,20 @@
-from fastapi import APIRouter, HTTPException, status
+from fastapi import APIRouter, HTTPException, status, Depends
 from typing import List, Optional, Any
 
-from core.dtos.responses_dto import GeneralResponse 
-
-from core.services.tag_service import TagService
 from adapter.database.tag_repository import TagRepository
-from core.dtos.tag_dto import TagCreateDTO, TagOutDTO, TagUpdateDTO
 
+from core.dtos.tag_dto import TagCreateDTO, TagOutDTO, TagUpdateDTO
+from core.dtos.responses_dto import GeneralResponse 
+from core.services.tag_service import TagService
+from core.dependencies.auth_dependencies import get_current_admin_user
 
 router = APIRouter(prefix="/tags", tags=["Tags"])
 
 service = TagService(TagRepository()) 
 
 @router.post("/", response_model=GeneralResponse)
-async def create_tags(dto: TagCreateDTO):
+async def create_tags(dto: TagCreateDTO, 
+                      current_user_id: str = Depends(get_current_admin_user)):
     try:
         created_tag_dto = await service.create_tag(dto) 
         
@@ -83,7 +84,8 @@ async def get_all_tags():
         )
 
 @router.patch("/{name}", response_model=GeneralResponse)
-async def update_tag(name: str, dto: TagUpdateDTO):
+async def update_tag(name: str, dto: TagUpdateDTO, 
+                     current_user_id: str = Depends(get_current_admin_user)):
     try:
         updated_tag_dto = await service.update_tag(name, dto)
         
@@ -106,7 +108,8 @@ async def update_tag(name: str, dto: TagUpdateDTO):
         )
 
 @router.delete("/{name}", response_model=GeneralResponse)
-async def delete_tag(name: str):
+async def delete_tag(name: str, 
+                     current_user_id: str = Depends(get_current_admin_user)):
     try:
         delete_result = await service.delete_tag(name)
         
@@ -127,3 +130,4 @@ async def delete_tag(name: str):
             status=False,
             response_obj={"message": f"An unexpected error occurred: {str(e)}"}
         )
+

--- a/unet360-api/adapter/api/upload_routes.py
+++ b/unet360-api/adapter/api/upload_routes.py
@@ -1,0 +1,84 @@
+from fastapi import APIRouter, File, UploadFile, HTTPException, status, Request, Depends
+from typing import Optional, Any
+import logging
+
+from core.dtos.responses_dto import GeneralResponse
+
+from supabase import Client as SupabaseClient
+
+from core.dependencies.auth_dependencies import get_current_admin_user
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+
+router = APIRouter(prefix="/upload", tags=["Uploads"])
+
+SUPABASE_BUCKET_NAME = "virtual-environment-images"
+
+
+@router.post("/image", response_model=GeneralResponse)
+async def upload_image(
+    request: Request,
+    file: UploadFile = File(...),
+    current_user_id: str = Depends(get_current_admin_user)
+):
+    try:
+        supabase_client: SupabaseClient = request.app.state.supabase
+        
+        if not file.content_type.startswith("image/"):
+            return GeneralResponse(
+                http_code=status.HTTP_400_BAD_REQUEST,
+                status=False,
+                response_obj={"message": "Invalid file type. Only image files are allowed."}
+            )
+
+        contents = await file.read()
+        
+        file_extension = file.filename.split(".")[-1] if "." in file.filename else "png"
+        file_path_in_bucket = f"{current_user_id}/{file.filename}" 
+        
+        response_storage = supabase_client.storage.from_(SUPABASE_BUCKET_NAME).upload(
+            file_path_in_bucket,
+            contents,
+            {"content-type": file.content_type}
+        )
+
+        if response_storage.status_code == 200:
+            signed_url_response = supabase_client.storage.from_(SUPABASE_BUCKET_NAME).create_signed_url(
+                file_path_in_bucket,
+                60
+            )
+            
+            signed_url = signed_url_response.data.signedUrl if signed_url_response.data else None
+
+            return GeneralResponse(
+                http_code=status.HTTP_201_CREATED,
+                status=True,
+                response_obj={
+                    "message": "Image uploaded successfully to private bucket.",
+                    "file_path": file_path_in_bucket,
+                    "signed_url": signed_url
+                }
+            )
+        else:
+            error_message = f"Supabase Storage upload failed: {response_storage.json()}"
+            return GeneralResponse(
+                http_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                status=False,
+                response_obj={"message": error_message}
+            )
+
+    except HTTPException as e:
+        return GeneralResponse(
+            http_code=e.status_code,
+            status=False,
+            response_obj={"message": e.detail}
+        )
+    except Exception as e:
+        logger.error(f"An unexpected error occurred during image upload: {e}", exc_info=True)
+        return GeneralResponse(
+            http_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            status=False,
+            response_obj={"message": f"An unexpected error occurred: {str(e)}"}
+        )
+

--- a/unet360-api/core/dependencies/auth_dependencies.py
+++ b/unet360-api/core/dependencies/auth_dependencies.py
@@ -1,0 +1,19 @@
+from fastapi import Request, HTTPException, Depends, status
+
+async def get_current_admin_user(request: Request):
+    user_id = request.state.user_id
+    user_role = request.state.user_role
+
+    if not user_id or not user_role:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Authentication required. User information not found in request state."
+        )
+
+    if user_role != "admin":
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Access denied. Only administrators can perform this operation."
+        )
+    
+    return user_id

--- a/unet360-api/core/dtos/auth_dto.py
+++ b/unet360-api/core/dtos/auth_dto.py
@@ -1,0 +1,17 @@
+from pydantic import BaseModel, Field
+from typing import Optional
+
+class UserSignUpDTO(BaseModel):
+    email: str
+    password: str
+
+class UserLoginDTO(BaseModel):
+    email: str
+    password: str
+
+class AuthResponseDTO(BaseModel):
+    access_token: str
+    token_type: str = "bearer"
+    user_id: str
+    user_role: Optional[str] = None
+    expires_in: Optional[int] = None

--- a/unet360-api/core/middleware/auth_middleware.py
+++ b/unet360-api/core/middleware/auth_middleware.py
@@ -1,0 +1,139 @@
+from fastapi import Request, HTTPException, status
+from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
+from starlette.responses import Response, JSONResponse # <-- Importa JSONResponse
+from starlette.types import ASGIApp
+import logging
+
+from supabase import Client as SupabaseClient
+
+from core.services.tenant_service import TenantService
+from adapter.database.tenant_repository import TenantRepository
+from core.dtos.responses_dto import GeneralResponse 
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+
+class AuthMiddleware(BaseHTTPMiddleware):
+    def __init__(self, app: ASGIApp):
+        super().__init__(app)
+        self.tenant_service = TenantService(TenantRepository())
+        
+        self.excluded_paths = [
+            "/",
+            "/auth/signup",
+            "/auth/login",
+        ]
+
+    async def dispatch(self, request: Request, call_next):
+        # Si la ruta está excluida, simplemente la pasa
+        if request.url.path in self.excluded_paths:
+            return await call_next(request)
+
+        if request.url.path == "/auth/status":
+            try:
+                auth_header = request.headers.get("Authorization")
+                if auth_header and auth_header.startswith("Bearer "):
+                    access_token = auth_header.split(" ", 1)[1]
+                    supabase_client: SupabaseClient = request.app.state.supabase
+                    user_response = supabase_client.auth.get_user(access_token)
+                    
+                    if user_response.user is not None:
+                        request.state.user_id = user_response.user.id
+                        tenant_profile = await self.tenant_service.get_tenant_by_supabase_user_id(request.state.user_id)
+                        request.state.user_role = tenant_profile.role if tenant_profile else None
+                        logger.info(f"Auth status check: User {request.state.user_id} authenticated.")
+                return await call_next(request)
+            except Exception as e:
+                logger.warning(f"Auth status check failed to validate token: {e}")
+                return await call_next(request)
+
+        auth_header = request.headers.get("Authorization")
+        if not auth_header:
+            return JSONResponse(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                content=GeneralResponse(
+                    http_code=status.HTTP_401_UNAUTHORIZED,
+                    status=False,
+                    response_obj={"message": "Authorization header missing"}
+                ).model_dump()
+            )
+
+        token_type, access_token = None, None
+        if auth_header.startswith("Bearer "):
+            try:
+                token_type, access_token = auth_header.split(" ", 1)
+            except ValueError:
+                # --- CAMBIO AQUI: Devolver JSONResponse directamente ---
+                return JSONResponse(
+                    status_code=status.HTTP_401_UNAUTHORIZED,
+                    content=GeneralResponse(
+                        http_code=status.HTTP_401_UNAUTHORIZED,
+                        status=False,
+                        response_obj={"message": "Invalid Authorization header format. Expected 'Bearer <token>'."}
+                    ).model_dump()
+                )
+        
+        if token_type != "Bearer" or not access_token:
+            # --- CAMBIO AQUI: Devolver JSONResponse directamente ---
+            return JSONResponse(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                content=GeneralResponse(
+                    http_code=status.HTTP_401_UNAUTHORIZED,
+                    status=False,
+                    response_obj={"message": "Invalid token type. Expected 'Bearer'."}
+                ).model_dump()
+            )
+
+        supabase_client: SupabaseClient = request.app.state.supabase
+        user_id = None
+        user_role = None
+
+        try:
+            user_response = supabase_client.auth.get_user(access_token) 
+            
+            if user_response.user is None:
+                # --- CAMBIO AQUI: Devolver JSONResponse directamente ---
+                return JSONResponse(
+                    status_code=status.HTTP_401_UNAUTHORIZED,
+                    content=GeneralResponse(
+                        http_code=status.HTTP_401_UNAUTHORIZED,
+                        status=False,
+                        response_obj={"message": "Invalid or expired token. User not found in Supabase."}
+                    ).model_dump()
+                )
+            
+            user_id = user_response.user.id
+
+            tenant_profile = await self.tenant_service.get_tenant_by_supabase_user_id(user_id)
+            
+            if not tenant_profile:
+                # --- CAMBIO AQUI: Devolver JSONResponse directamente ---
+                return JSONResponse(
+                    status_code=status.HTTP_403_FORBIDDEN,
+                    content=GeneralResponse(
+                        http_code=status.HTTP_403_FORBIDDEN,
+                        status=False,
+                        response_obj={"message": "User profile not found in application database. Access denied."}
+                    ).model_dump()
+                )
+            
+            user_role = tenant_profile.role
+
+            request.state.user_id = user_id
+            request.state.user_role = user_role
+            logger.info(f"Authenticated user: {user_id} with role: {user_role}")
+
+        except Exception as e:
+            logger.error(f"Authentication failed: {e}")
+            return JSONResponse(
+                status_code=status.HTTP_401_UNAUTHORIZED, # O 500, pero 401 es más apropiado para fallos de auth
+                content=GeneralResponse(
+                    http_code=status.HTTP_401_UNAUTHORIZED,
+                    status=False,
+                    response_obj={"message": f"Authentication failed: {str(e)}"}
+                ).model_dump()
+            )
+
+        response = await call_next(request)
+        return response
+

--- a/unet360-api/core/middleware/auth_middleware.py
+++ b/unet360-api/core/middleware/auth_middleware.py
@@ -22,6 +22,9 @@ class AuthMiddleware(BaseHTTPMiddleware):
             "/",
             "/auth/signup",
             "/auth/login",
+            "/docs",
+            "/redoc",       
+            "/openapi.json",
         ]
 
     async def dispatch(self, request: Request, call_next):

--- a/unet360-api/core/services/auth_service.py
+++ b/unet360-api/core/services/auth_service.py
@@ -1,0 +1,139 @@
+from typing import Optional, Any
+import logging
+from fastapi import HTTPException, status 
+from gotrue.errors import AuthApiError 
+from supabase import Client as SupabaseClient 
+
+from core.dtos.auth_dto import UserSignUpDTO, UserLoginDTO, AuthResponseDTO 
+from core.services.tenant_service import TenantService 
+from core.dtos.tenant_dto import TenantCreateDTO
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO) 
+
+
+class AuthService:
+    def __init__(self, supabase_client: SupabaseClient, tenant_service: TenantService):
+        self.supabase_client = supabase_client
+        self.tenant_service = tenant_service
+
+    async def signup_user(self, user_data: UserSignUpDTO) -> dict:
+        if not user_data.email.endswith('@unet.edu.ve'):
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Registration allowed only for '@unet.edu.ve' email addresses."
+            )
+        
+        try:
+            response_supabase = self.supabase_client.auth.sign_up(
+                {
+                    "email": user_data.email,
+                    "password": user_data.password
+                }
+            )
+
+            if response_supabase.user is None:
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail="Supabase signup failed: Could not create user."
+                )
+            
+            supabase_user_id = response_supabase.user.id
+
+            tenant_create_dto_instance = TenantCreateDTO(
+                name=user_data.email.split('@')[0],
+                supabase_user_id=supabase_user_id,
+                role="viewer" # Asignar un rol por defecto
+            )
+            
+            await self.tenant_service.create_tenant(tenant_create_dto_instance)
+
+            return {"message": "User successfully registered. Please check your email to confirm your account."}
+
+        except AuthApiError as e:
+            logger.error(f"AuthApiError during signup: {e.message}")
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=e.message
+            )
+        except HTTPException as e:
+            raise e
+        except Exception as e:
+            logger.error(f"An unexpected error occurred during signup in service: {e}", exc_info=True)
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail=f"An unexpected error occurred: {str(e)}"
+            )
+
+    async def login_user(self, user_data: UserLoginDTO) -> AuthResponseDTO:
+        try:
+            response_supabase = self.supabase_client.auth.sign_in_with_password(
+                {
+                    "email": user_data.email,
+                    "password": user_data.password
+                }
+            )
+
+            if response_supabase.user is None or response_supabase.session is None:
+                raise HTTPException(
+                    status_code=status.HTTP_401_UNAUTHORIZED,
+                    detail="Login failed: Invalid credentials or email not confirmed."
+                )
+
+            supabase_user_id = response_supabase.user.id
+            access_token = response_supabase.session.access_token
+            expires_in = response_supabase.session.expires_in
+
+            tenant = await self.tenant_service.get_tenant_by_supabase_user_id(supabase_user_id)
+            
+            if not tenant:
+                raise HTTPException(
+                    status_code=status.HTTP_404_NOT_FOUND,
+                    detail="User authenticated, but tenant profile not found in MongoDB."
+                )
+
+            auth_response = AuthResponseDTO(
+                access_token=access_token,
+                user_id=supabase_user_id,
+                user_role=tenant.role,
+                expires_in=expires_in
+            )
+
+            return auth_response
+
+        except AuthApiError as e:
+            logger.error(f"AuthApiError during login: {e.message}")
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail=e.message
+            )
+        except HTTPException as e:
+            raise e
+        except Exception as e:
+            logger.error(f"An unexpected error occurred during login in service: {e}", exc_info=True)
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail=f"An unexpected error occurred: {str(e)}"
+            )
+
+    async def logout_user(self, user_id: str):
+        try:
+            self.supabase_client.auth.sign_out() 
+            
+            logger.info(f"User {user_id} successfully logged out from Supabase.")
+            
+            return {"message": "User successfully logged out."}
+
+        except AuthApiError as e:
+            logger.error(f"AuthApiError during logout for user {user_id}: {e.message}")
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"Logout failed: {e.message}"
+            )
+        except Exception as e:
+            logger.error(f"An unexpected error occurred during logout for user {user_id}: {e}", exc_info=True)
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail=f"An unexpected error occurred: {str(e)}"
+            )
+

--- a/unet360-api/core/services/upload_service.py
+++ b/unet360-api/core/services/upload_service.py
@@ -1,0 +1,50 @@
+from typing import Optional, Any
+import logging
+
+from fastapi import HTTPException, status
+from supabase import Client as SupabaseClient
+from storage3.exceptions import StorageApiError
+
+from core.dtos.responses_dto import GeneralResponse
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+
+class UploadService:
+    def __init__(self, supabase_client: SupabaseClient):
+        self.supabase_client = supabase_client
+        self.supabase_bucket_name = "virtual-environment-images"
+
+    async def upload_image(self, file_content: bytes, file_name: str, file_content_type: str, user_id: str) -> dict:
+        try:
+            file_path_in_bucket = f"{file_name}" 
+            
+            response_storage = self.supabase_client.storage.from_(self.supabase_bucket_name).upload(
+                file_path_in_bucket,
+                file_content,
+                {"content-type": file_content_type}
+            )
+
+            public_url_response = self.supabase_client.storage.from_(self.supabase_bucket_name).get_public_url(file_path_in_bucket)
+            uploaded_file_path_from_supabase = response_storage.full_path
+
+            return {
+                "message": "Image uploaded successfully to private bucket.",
+                "file_path": uploaded_file_path_from_supabase,
+                "signed_url": public_url_response
+            }
+
+        except StorageApiError as e:
+            logger.error(f"Supabase Storage API error during image upload: {e}", exc_info=True)
+            error_detail = e.message if hasattr(e, 'message') else str(e)
+            status_code_from_api = e.status_code if hasattr(e, 'status_code') else status.HTTP_500_INTERNAL_SERVER_ERROR
+            raise HTTPException(
+                status_code=status_code_from_api,
+                detail=f"Supabase Storage upload failed: {error_detail}"
+            )
+        except Exception as e:
+            logger.error(f"An unexpected error occurred during image upload: {e}", exc_info=True)
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail=f"An unexpected error occurred: {str(e)}"
+            )

--- a/unet360-api/requirements.txt
+++ b/unet360-api/requirements.txt
@@ -6,3 +6,4 @@ python-dotenv>=0.19.0
 pymongo>=4.3.3
 beanie>=1.20.0
 supabase
+python-multipart


### PR DESCRIPTION
### Descripción:
Este PR implementa un protocolo de seguridad y protección de los activos informáticos, instaurando un sistema completo de autenticación y autorización de usuarios mediante un Middleware, protegiendo las rutas en el backend.

### Cambios Realizados:
- **Autenticación de Usuarios:**
    - Implementación de registro (`signup`) e inicio de sesión (`login`) usando la API de Supabase con email/contraseña.
    - Validación de correos electrónicos restringida a `@unet.edu.ve`.
    - Vinculación de usuarios creados en Supabase con la tabla `tenant` de MongoDB mediante el ID de Supabase.
- **Middleware de Autenticación (`AuthMiddleware`):**
    - Creación e integración de un Middleware global para interceptar y validar tokens JWT en cada petición.
    - Configuración de rutas excluidas del Middleware: `/`, `/auth/signup`, `/auth/login`, `/auth/status`.
- **Autorización por Rol:**
    - Implementación de lógica para que solo usuarios con rol "admin" autenticados puedan acceder a las rutas de creación (`POST`), actualización (`PATCH`) y eliminación (`DELETE`) de los modelos `nodes`, `locations` y `tags`.
- **Manejo de Sesiones:**
    - Creación de un endpoint `POST /auth/logout` para cerrar la sesión del usuario en Supabase.
- **Endpoint de Estado de Autenticación:**
    - Implementación de `GET /auth/status` para que el frontend verifique si un usuario está autenticado y obtenga su `user_id` y `user_role`.
- **Subida Segura de Imágenes:**
    - Creación de un endpoint `POST /upload/image` para subir imágenes a un bucket privado de Supabase Storage, devolviendo URLs firmadas, protegido por rol de administrador.
- **Centralización de Mensajes de Error:**
    - Uso consistente de constantes de error (`CREATE_ERROR_MESSAGE`, `OBJECT_NOT_FOUND_ERROR_MESSAGE`) en los servicios para respuestas uniformes.
- **Formato de Respuesta Estandarizado:**
    - Integración del DTO `GeneralResponse` en todas las respuestas de la API, unificando el formato de éxito y error.
- **Organización del Código:**
    - Aplicación de principios de abstracción y modularización (servicios, repositorios, DTOs, mappers, dependencias, middleware).

### Consideraciones:
- La integración con Google OAuth no fue posible debido a limitaciones de permisos de acceso a Google Cloud con la cuenta institucional.
- La instanciación de los servicios y repositorios en las rutas se mantiene global.
- Los repositorios de `Node`, `Location` y `Tag` no utilizan `fetch_link()` por la misma restricción, requiriendo que la función de mapeo (`node_mappers.py`) realice los fetches explícitos de los Links.

### ¿Como probarlo?:
1.  **Iniciar el backend:** `python main.py` (asegurarse de que el contenedor Docker esté levantado).
2.  **Probar Autenticación:**
    * `POST /auth/signup`: Registrar un nuevo usuario (`@unet.edu.ve`). Verificar mensaje de confirmación de email.
    * `POST /auth/login`: Iniciar sesión con el usuario registrado (confirmado, si aplica). Copiar el `access_token`.
3.  **Probar Acceso a Rutas Protegidas (Ej. `POST /locations/`):**
    * **Sin token:** Esperar `http_code: 401` (`Authorization header missing`).
    * **Con token de rol "viewer":** Esperar `http_code: 403` (`Access denied. Only administrators...`).
    * **Con token de rol "admin" (cambiar rol en MongoDB Compass):** Esperar `http_code: 201` (creación exitosa).
4.  **Probar Acceso a Rutas de Lectura (Ej. `GET /nodes/`):**
    * **Sin token:** Debe funcionar y devolver datos.
    * **Con token (viewer/admin):** Debe funcionar.
5.  **Probar Estado de Autenticación (`GET /auth/status`):**
    * **Sin token:** Esperar `http_code: 200`, `status: false`, `is_authenticated: false`.
    * **Con token (viewer/admin):** Esperar `http_code: 200`, `status: true`, `is_authenticated: true`, con `user_id` y `user_role`.
6.  **Probar Cierre de Sesión (`POST /auth/logout`):**
    * Usar un token válido. Esperar `http_code: 200`, `message: "User successfully logged out."`.
    * Intentar usar el mismo token en otra ruta protegida; debe fallar con `401`.
7.  **Probar Subida de Imágenes (`POST /upload/image`):**
    * **Solo con token de rol "admin"** (usando `multipart/form-data` en Postman).
    * Esperar `http_code: 201` y una `signed_url`.